### PR TITLE
chore(cd): update e2e-extension-service version to 2021.07.30.00.47.44.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:7e8d2f30fbe2f5b3d3ca9119a4adbae43c87521c798815cce7823fb14cf047b3
+      imageId: sha256:2087e5ff9a2570ecf2d93b4f800a98cd21fb8495512822bd2f4143f2b0939c41
       repository: armory/e2e-extension-service
-      tag: 2021.07.30.00.31.35.main
+      tag: 2021.07.30.00.47.44.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: e9ec4e60fde119d8cc8a4468bcfa24d3180ced42
+      sha: d21eee3c176a38d77246f2c7a3b95815fd1dd26a


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "f661f11a649e0c11de1ac2c1964de72e4ec82bf7"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:2087e5ff9a2570ecf2d93b4f800a98cd21fb8495512822bd2f4143f2b0939c41",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.07.30.00.47.44.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "d21eee3c176a38d77246f2c7a3b95815fd1dd26a"
      }
    },
    "name": "e2e-extension-service"
  }
}
```