### PR TITLE
chore(cd): update e2e-extension-service version to 2021.07.30.16.59.50.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:5fe33f30806f9ddc55a1bea7f858159c9790676e2c8e409626c64102fb779ee3
+      imageId: sha256:76f0f73f108e9b7641318841003d4ca19a7eaebec1a38816867f23383642dcc4
       repository: armory/e2e-extension-service
-      tag: 2021.07.30.16.45.15.main
+      tag: 2021.07.30.16.59.50.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 381520e8803b552f5d84cc158b5dd40fb9f28996
+      sha: 9c5388fd18d479d4de3804c01cf3b78958342217


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "831963f5eccd3a0356e1c1370a607aa133591b3a"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:76f0f73f108e9b7641318841003d4ca19a7eaebec1a38816867f23383642dcc4",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.07.30.16.59.50.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "9c5388fd18d479d4de3804c01cf3b78958342217"
      }
    },
    "name": "e2e-extension-service"
  }
}
```