### PR TITLE
chore(cd): update e2e-extension-service version to 2021.07.30.18.17.48.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:089c9d25bb4907bb0f9a386520f4b68fd2d3048fff511ef9cb21e3ab58dd2b30
+      imageId: sha256:f127f934287ac4c2e80b45a33acc07b97a31e9cc280f4b17f96517873383b1aa
       repository: armory/e2e-extension-service
-      tag: 2021.07.30.17.23.52.main
+      tag: 2021.07.30.18.17.48.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 4b5c5612fcf73fa6f366dbf96636c1fe62623340
+      sha: 02c48bbcf7e972468c135054c63bb8a80b7d2683


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "dd0983e7b73d7fa75e28ce3c205caa0568db1efb"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:f127f934287ac4c2e80b45a33acc07b97a31e9cc280f4b17f96517873383b1aa",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.07.30.18.17.48.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "02c48bbcf7e972468c135054c63bb8a80b7d2683"
      }
    },
    "name": "e2e-extension-service"
  }
}
```