### PR TITLE
chore(cd): update e2e-extension-service version to 2021.08.01.02.35.15.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:7ad34460bfe4431175d29fc658e7aa4ac08f3b14d4bbb8b354b63c8784cf9870
+      imageId: sha256:37df459c855ad3a2e75ee38cbfeab474e874b341a6e422e66eaef37c0905b654
       repository: armory/e2e-extension-service
-      tag: 2021.08.01.02.07.14.main
+      tag: 2021.08.01.02.35.15.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: c719bf11c28ebd82944b0702997c8dfc720e2b46
+      sha: c42536ea312784571062a2f290f1aec73218fde3


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "830b39ab7fa0fc468909d2807637ce7abe5e5e17"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:37df459c855ad3a2e75ee38cbfeab474e874b341a6e422e66eaef37c0905b654",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.08.01.02.35.15.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "c42536ea312784571062a2f290f1aec73218fde3"
      }
    },
    "name": "e2e-extension-service"
  }
}
```