### PR TITLE
chore(cd): update e2e-extension-service version to 2021.08.24.05.08.07.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:ede0922eb99adccdfef557abfe0abac00de0af172dc0260ccb7adb1f9a078c04
+      imageId: sha256:dc53962ebc53354bffa63b7bc8e99a65864183d94c6c3c9786875ee350dd866d
       repository: armory/e2e-extension-service
-      tag: 2021.08.24.05.03.40.main
+      tag: 2021.08.24.05.08.07.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 1ad3fa9b2c4e389bb65e483b898b049efba96820
+      sha: e303495aeb0af6bef0fbc9a1440f0f80329b8a8d


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "b6da05b8350e9e98a919802b3f4616af013f8815"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:dc53962ebc53354bffa63b7bc8e99a65864183d94c6c3c9786875ee350dd866d",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.08.24.05.08.07.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "e303495aeb0af6bef0fbc9a1440f0f80329b8a8d"
      }
    },
    "name": "e2e-extension-service"
  }
}
```