### PR TITLE
chore(cd): update e2e-extension-service version to 2021.08.30.22.47.54.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:b535af54ea88ec87da9563b9e8954d314a10ae940a5e89fba8ad7c40acf00fe8
+      imageId: sha256:6b4fdd63b7392c15f78b18b316dbf1de6230c758fcad682656b07b928a7b2499
       repository: armory/e2e-extension-service
-      tag: 2021.08.30.22.43.52.main
+      tag: 2021.08.30.22.47.54.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: aa3296af1320c514147c6a4166cc599f81e85d83
+      sha: 44765b9b08564ede6d83a29ef7a0bb23ea79a519


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "9c47eb4f425457a185f89de98066ea2c3cba026f"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:6b4fdd63b7392c15f78b18b316dbf1de6230c758fcad682656b07b928a7b2499",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.08.30.22.47.54.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "44765b9b08564ede6d83a29ef7a0bb23ea79a519"
      }
    },
    "name": "e2e-extension-service"
  }
}
```