### PR TITLE
chore(cd): update e2e-extension-service version to 2021.09.01.16.54.49.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:1297e4acd1022eda3c4fce443554fe4ab6da9ee468bfef963164539014b6e5c1
+      imageId: sha256:f1dac2d1d9af0d2b70b98138bdd4616ac492fea82b9a5061645c3c131daca384
       repository: armory/e2e-extension-service
-      tag: 2021.09.01.00.13.37.main
+      tag: 2021.09.01.16.54.49.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 5b99113fe74f0d610b75dde3976e7a1ef3619c12
+      sha: 274252bf0e1cd294531cc99218d31819cdd8f852


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "7b861232ab25bf95f72fc01e5502f64a43966b77"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:f1dac2d1d9af0d2b70b98138bdd4616ac492fea82b9a5061645c3c131daca384",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.09.01.16.54.49.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "274252bf0e1cd294531cc99218d31819cdd8f852"
      }
    },
    "name": "e2e-extension-service"
  }
}
```