### PR TITLE
chore(cd): update e2e-extension-service version to 2021.09.16.23.25.42.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:5b632ed11080ff80c4b4b3e6c8f810258147037ac8933f1eb500329402131b12
+      imageId: sha256:1148d6805826f71a9eebf93ca346564db28b61ea3d52d6e3ad1d8d133f03eb27
       repository: armory/e2e-extension-service
-      tag: 2021.09.16.23.21.24.main
+      tag: 2021.09.16.23.25.42.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 24a5e4ae5696e32fb7d614a14bfb2dcf23d3e7d8
+      sha: 55701b7b3c781eb7b5da2bf6473ea26eea0e4f0a


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "74f8d581741d9ae2744e0b81869d80fa37a40dc5"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:1148d6805826f71a9eebf93ca346564db28b61ea3d52d6e3ad1d8d133f03eb27",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.09.16.23.25.42.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "55701b7b3c781eb7b5da2bf6473ea26eea0e4f0a"
      }
    },
    "name": "e2e-extension-service"
  }
}
```