### PR TITLE
chore(cd): update e2e-extension-service version to 2021.09.17.20.08.02.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:d1837a81922db144104f2a039024911bfccddf2cfb21f63c78fa311cec0ac3e7
+      imageId: sha256:5e4eae4b41abdc6e26f948e29348707f31caee4021f78959f28d0a1ac6109eb1
       repository: armory/e2e-extension-service
-      tag: 2021.09.17.20.04.20.main
+      tag: 2021.09.17.20.08.02.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 78619e07894cadfda10e34c7ffdd52adb70ae1ab
+      sha: 8d8d1e23dedf5f1e77d209a51c8d063cad67d7b1


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "f365aad68e800e74825d6a09a6fe32d3514bad42"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:5e4eae4b41abdc6e26f948e29348707f31caee4021f78959f28d0a1ac6109eb1",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.09.17.20.08.02.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "8d8d1e23dedf5f1e77d209a51c8d063cad67d7b1"
      }
    },
    "name": "e2e-extension-service"
  }
}
```