### PR TITLE
chore(cd): update e2e-extension-service version to 2021.10.11.17.35.56.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:68d179c5d938b93b4849271ab2d38560b9c1184849bf32a1aa98707eb18c8838
+      imageId: sha256:e05025874f3a15667b10c1cffc67d2be916b884e7e712b279037ead583d33124
       repository: armory/e2e-extension-service
-      tag: 2021.10.05.21.24.45.main
+      tag: 2021.10.11.17.35.56.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: a621faf049e6256078c576a6beb520cf840d5e1b
+      sha: 87c2059347f62174de846cd6a13884e7d1b19b50


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "5d81285ae178b9372cbc11365b93d048d319f095"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:e05025874f3a15667b10c1cffc67d2be916b884e7e712b279037ead583d33124",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.10.11.17.35.56.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "87c2059347f62174de846cd6a13884e7d1b19b50"
      }
    },
    "name": "e2e-extension-service"
  }
}
```