### PR TITLE
chore(cd): update e2e-extension-service version to 2021.10.16.00.10.02.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:dedcb1e0e058df5cf6bcdf12c6b391fbcea94a50cb5a220f0c052461343682ee
+      imageId: sha256:9ba2de5fe94a9a3684f8b66b3efa928fc89baeb95f5fcbdd9e1bfa34204cc148
       repository: armory/e2e-extension-service
-      tag: 2021.10.11.17.40.24.main
+      tag: 2021.10.16.00.10.02.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 183fbc7a977ba107e189f202392eb46531fcb640
+      sha: 4cf6794b3b803e40272a26754c05b940a206fde4


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "52d528d5f189b9df3ee681a463b8705d03d7e96c"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:9ba2de5fe94a9a3684f8b66b3efa928fc89baeb95f5fcbdd9e1bfa34204cc148",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.10.16.00.10.02.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "4cf6794b3b803e40272a26754c05b940a206fde4"
      }
    },
    "name": "e2e-extension-service"
  }
}
```