### PR TITLE
chore(cd): update e2e-extension-service version to 2021.10.28.14.44.08.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:131326db8079a2d3b9b946f35a2dbf251cc172fe9f1269305aeca4b03443fafb
+      imageId: sha256:2d2b4ad81403b480f9a0e346dd83ac83bb6a1d0f5a5cea582cd44a38872befb2
       repository: armory/e2e-extension-service
-      tag: 2021.10.16.01.06.36.main
+      tag: 2021.10.28.14.44.08.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 2c72546a7d760d7f1117b98295ea380996f8a4a1
+      sha: 6178980bee3139b44d434cf085bb802d34ddf7ad


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "9e619014e9a718ab88a1d360337628a99b7740c9"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:2d2b4ad81403b480f9a0e346dd83ac83bb6a1d0f5a5cea582cd44a38872befb2",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.10.28.14.44.08.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "6178980bee3139b44d434cf085bb802d34ddf7ad"
      }
    },
    "name": "e2e-extension-service"
  }
}
```