### PR TITLE
chore(cd): update e2e-extension-service version to 2021.11.04.22.53.25.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:e5deaa6523a228a70eeee5bcb37b8b7889630de5afafd3c02034483c7e065f5b
+      imageId: sha256:3eca7a3d68a0b2a981d5fbbc2c3e7f1d75cbbc1336d423b9d3e2ecfed471e806
       repository: armory/e2e-extension-service
-      tag: 2021.11.04.22.49.33.main
+      tag: 2021.11.04.22.53.25.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: ba5bd54321bbc14b6380cca1c0ededd27bffff80
+      sha: 30ddda08622d72a1a4d3081f412c09952a329ac8


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "034b4ba2df4250224b78c5b6124182e6d72b1764"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:3eca7a3d68a0b2a981d5fbbc2c3e7f1d75cbbc1336d423b9d3e2ecfed471e806",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.11.04.22.53.25.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "30ddda08622d72a1a4d3081f412c09952a329ac8"
      }
    },
    "name": "e2e-extension-service"
  }
}
```