### PR TITLE
chore(cd): update e2e-extension-service version to 2021.11.12.00.58.05.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:d1b001dac9b62c1ced7961b0eb6f0349db67aa122f9000f00418d700d9c116f7
+      imageId: sha256:672b4a481c4c503a18e4d52981f3d34cc18968c37d172298d4fa4a7f944d8b44
       repository: armory/e2e-extension-service
-      tag: 2021.11.11.23.39.22.main
+      tag: 2021.11.12.00.58.05.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 78159f5c5552775206031bd9f69e0afdb1f2abdb
+      sha: fc3580683513786c48bda531005608815f5f286c


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "a794730b84207ac677d95dc99ebe8d1d6d50832a"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:672b4a481c4c503a18e4d52981f3d34cc18968c37d172298d4fa4a7f944d8b44",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.11.12.00.58.05.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "fc3580683513786c48bda531005608815f5f286c"
      }
    },
    "name": "e2e-extension-service"
  }
}
```