### PR TITLE
chore(cd): update e2e-extension-service version to 2021.12.03.17.14.20.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:b696e8ece20bf74e844b937ca4dfba3e62dc9017de650f33e26aa3c705ab0bb1
+      imageId: sha256:c813f63a202210b500cde4db60a5e2751448a9d19124c77f8183d1eaf4af35be
       repository: armory/e2e-extension-service
-      tag: 2021.12.03.17.10.36.main
+      tag: 2021.12.03.17.14.20.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 1ce960c669938ddb8ea4b8a1b4467a3588d9290f
+      sha: 896165a09f07859cb16da4e7997ff3c143533a8d


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "d5aa51e269e5c8bb7f80801ccbd78414e4fe4d12"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:c813f63a202210b500cde4db60a5e2751448a9d19124c77f8183d1eaf4af35be",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.12.03.17.14.20.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "896165a09f07859cb16da4e7997ff3c143533a8d"
      }
    },
    "name": "e2e-extension-service"
  }
}
```