### PR TITLE
chore(cd): update e2e-extension-service version to 2021.12.14.04.03.37.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:144a44c2e1560a21015f6fb97285b05b42dec344b6d9b7e01eff36747b394742
+      imageId: sha256:374d2bec16a0edcc07286937fd60131ba749bcc3555052dfe6633b70f01233ad
       repository: armory/e2e-extension-service
-      tag: 2021.12.13.20.06.09.main
+      tag: 2021.12.14.04.03.37.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 8e8f004328f6db07e449a3b102c754399c7a70d9
+      sha: 9fd2e46d279202b0e8270b9fb951613beb66d4cd


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "066017f396cf43cbefb937d5a4671408873ac4af"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:374d2bec16a0edcc07286937fd60131ba749bcc3555052dfe6633b70f01233ad",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.12.14.04.03.37.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "9fd2e46d279202b0e8270b9fb951613beb66d4cd"
      }
    },
    "name": "e2e-extension-service"
  }
}
```