### PR TITLE
chore(cd): update e2e-extension-service version to 2021.12.21.15.48.11.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:8375c4552f1937f44071a6dde4c60a45ea359500f5d80ffbe1c940113ced7692
+      imageId: sha256:b881ee94af6e331a261752c7331a8b11e0c0f37352ad3f98f989ec8c312535e1
       repository: armory/e2e-extension-service
-      tag: 2021.12.21.03.49.54.main
+      tag: 2021.12.21.15.48.11.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 139aa14265343faf458e335e5f6dc039cb145109
+      sha: 8b23c7d003b814cee4890d5e22d7e2ab69aedf10


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "69875e7137e4ac8ba7fc6fd247e559c71f02b542"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:b881ee94af6e331a261752c7331a8b11e0c0f37352ad3f98f989ec8c312535e1",
        "repository": "armory/e2e-extension-service",
        "tag": "2021.12.21.15.48.11.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "8b23c7d003b814cee4890d5e22d7e2ab69aedf10"
      }
    },
    "name": "e2e-extension-service"
  }
}
```