### PR TITLE
chore(cd): update e2e-extension-service version to 2022.01.28.03.39.53.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:1e02473875813ac7926414c9b2c3dfd4360897a48745ec4ed3a471e90da1b656
+      imageId: sha256:16b69ff6006531f13b60ab0639a2ff51aaab001d80e95ff2a3d66282e5e4caea
       repository: armory/e2e-extension-service
-      tag: 2022.01.28.03.35.37.main
+      tag: 2022.01.28.03.39.53.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: e2a0d30c790afa6d61db1b64cf4fe6b2dd6a5edb
+      sha: a32cf43f8a33adffd066237be5835bbf368c02b6


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "c36fe9f8a87120b3f0505a16cc06a577dcd56d68"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:16b69ff6006531f13b60ab0639a2ff51aaab001d80e95ff2a3d66282e5e4caea",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.01.28.03.39.53.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "a32cf43f8a33adffd066237be5835bbf368c02b6"
      }
    },
    "name": "e2e-extension-service"
  }
}
```