### PR TITLE
chore(cd): update e2e-extension-service version to 2022.03.08.21.59.22.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:5e69f359cab2c34aea8c3434a38dc2b666cb06713a7101a91237e8996554a2c6
+      imageId: sha256:1ecd46811452794a692a7a148749bf8d7e7017b09cd670c8490600482abe9339
       repository: armory/e2e-extension-service
-      tag: 2022.03.08.21.31.44.main
+      tag: 2022.03.08.21.59.22.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 3857a0f87fd2813620e97259a3e8181dee52bc75
+      sha: 8fc733470cade849dd4b533d4572a3b5eefc4b53


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "f487d1fa8a67cfd8520228788a02f6e73dea7098"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:1ecd46811452794a692a7a148749bf8d7e7017b09cd670c8490600482abe9339",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.03.08.21.59.22.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "8fc733470cade849dd4b533d4572a3b5eefc4b53"
      }
    },
    "name": "e2e-extension-service"
  }
}
```