### PR TITLE
chore(cd): update e2e-extension-service version to 2022.03.09.00.37.17.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:041841aa2e8e6f75d650ccdeb2af8574052e3e4266d9a3ed92cfbe1bc312302f
+      imageId: sha256:21315edbec051b41bd0d29cf5b7a9b9e9d6c1ec2d98a26d000a2260592eb0fe3
       repository: armory/e2e-extension-service
-      tag: 2022.03.08.22.06.30.main
+      tag: 2022.03.09.00.37.17.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: be77f5880b961c076039f0af90ef0f61847ecf2d
+      sha: c3609c97cc0503da80b101b0a02a39fedcc60654


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "8aca12610a1858f598c539e5d6f264de7f684ca5"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:21315edbec051b41bd0d29cf5b7a9b9e9d6c1ec2d98a26d000a2260592eb0fe3",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.03.09.00.37.17.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "c3609c97cc0503da80b101b0a02a39fedcc60654"
      }
    },
    "name": "e2e-extension-service"
  }
}
```