### PR TITLE
chore(cd): update e2e-extension-service version to 2022.03.09.01.51.49.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:ad64b6014e9ba9d8db046b19791b41a574348c51a0a6388f61cbe02d1e008ad7
+      imageId: sha256:8ef4506e78e1583ddccfe19c6d86e538af0707b77f5a39af19cc7efca4bc3c79
       repository: armory/e2e-extension-service
-      tag: 2022.03.09.01.48.00.main
+      tag: 2022.03.09.01.51.49.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: fb9a92dfa11b6ab064f3d93e44f69d777f54cf6a
+      sha: 22b7bceb669e727cf3b68f3bf57510365e5c3120


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "f06143b1b27fbd37578b123c9597bb3f1a4dd241"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:8ef4506e78e1583ddccfe19c6d86e538af0707b77f5a39af19cc7efca4bc3c79",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.03.09.01.51.49.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "22b7bceb669e727cf3b68f3bf57510365e5c3120"
      }
    },
    "name": "e2e-extension-service"
  }
}
```