### PR TITLE
chore(cd): update e2e-extension-service version to 2022.03.22.16.51.20.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:c4e8020c252ed80f52d71635b20813c1e8eabfcc4f2c3680332fe7d235e221e7
+      imageId: sha256:89d945f836f62097d93b1f0b6416e51193675b2c8233b98ed2e55d53cc82ea26
       repository: armory/e2e-extension-service
-      tag: 2022.03.22.16.36.36.main
+      tag: 2022.03.22.16.51.20.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 603ab7aa61d1b6269a2e9676643af8f5161f590f
+      sha: 16e0a99f8556f24da5ac76c59c81fee46144bf55


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "0f2032443f7b7fc0702c780bcf885f502d9bfa5a"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:89d945f836f62097d93b1f0b6416e51193675b2c8233b98ed2e55d53cc82ea26",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.03.22.16.51.20.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "16e0a99f8556f24da5ac76c59c81fee46144bf55"
      }
    },
    "name": "e2e-extension-service"
  }
}
```