### PR TITLE
chore(cd): update e2e-extension-service version to 2022.03.23.02.48.05.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:b4c024fa7a330fd7a573a666f231b068bf0a8d4c01d0360c1e2a96c520acfeda
+      imageId: sha256:f11d039f5e6e0fe6eb056031dd3c3ea69f49ea43827de929961225836beaf405
       repository: armory/e2e-extension-service
-      tag: 2022.03.23.02.44.11.main
+      tag: 2022.03.23.02.48.05.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: d39222aa2bd9c5b8dd0f87cb664e73ffca9af0d3
+      sha: 43cb527c76090ad89e3213ed0b4ae7f00326d9bc


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "6bf09f5cb8bf403c408302315855387aae79c80d"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:f11d039f5e6e0fe6eb056031dd3c3ea69f49ea43827de929961225836beaf405",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.03.23.02.48.05.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "43cb527c76090ad89e3213ed0b4ae7f00326d9bc"
      }
    },
    "name": "e2e-extension-service"
  }
}
```