### PR TITLE
chore(cd): update e2e-extension-service version to 2022.07.20.02.43.18.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   e2e-extension-service:
     baseService: e2e-oss-service
     image:
-      imageId: sha256:e8ea623d56eb51f6fe7ecf5b73f5dc4c5b3d1d72e53c7a8bb096d34bef32eba8
+      imageId: sha256:694a120084cad5e2240db306b0b8d31da4b390c074cc33367cf7bef5c5d3bfb0
       repository: armory/e2e-extension-service
-      tag: 2022.07.20.02.39.47.main
+      tag: 2022.07.20.02.43.18.main
     vcs:
       repo:
         orgName: armory-io
         repoName: e2e-extension-service
         type: github
-      sha: 601cdaac2ff22d9ef82859163d877377471f4efc
+      sha: 96cbce710358ed6d3d39fcbfc1503050725097ef


### PR DESCRIPTION
Event
```
{
  "branch": "main",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "armory-io",
        "repoName": "e2e-oss-service",
        "type": "github"
      },
      "sha": "1e2a5e75930fae55e96cb2dd5bdd848873fe1469"
    },
    "details": {
      "baseService": "e2e-oss-service",
      "image": {
        "imageId": "sha256:694a120084cad5e2240db306b0b8d31da4b390c074cc33367cf7bef5c5d3bfb0",
        "repository": "armory/e2e-extension-service",
        "tag": "2022.07.20.02.43.18.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "e2e-extension-service",
          "type": "github"
        },
        "sha": "96cbce710358ed6d3d39fcbfc1503050725097ef"
      }
    },
    "name": "e2e-extension-service"
  }
}
```